### PR TITLE
Remove config enabled check in the adapter

### DIFF
--- a/dr-shadow-spring-boot/src/main/java/com/expediagroup/library/drshadow/springboot/ShadowTrafficAdapter.java
+++ b/dr-shadow-spring-boot/src/main/java/com/expediagroup/library/drshadow/springboot/ShadowTrafficAdapter.java
@@ -179,7 +179,7 @@ public class ShadowTrafficAdapter {
             List<ListenableFuture<ResponseEntity<String>>> futures = new ArrayList<>();
 
             // Check whether shadow traffic is enabled and also generate a random number to see if it falls within percentage
-            if (shadowTrafficConfig != null && shadowTrafficConfig.isEnabled() && (random.nextInt(100) + 1) <= shadowTrafficConfig.getPercentage()) {
+            if (shadowTrafficConfig != null && (random.nextInt(100) + 1) <= shadowTrafficConfig.getPercentage()) {
 
                 if (drShadowHttpServletRequest == null) {
                     LOGGER.error("DrShadowHttpServletRequest is null. Shadow traffic will not be invoked.");

--- a/dr-shadow-spring-boot/src/test/java/com/expediagroup/library/drshadow/springboot/ShadowTrafficAdapterTest.java
+++ b/dr-shadow-spring-boot/src/test/java/com/expediagroup/library/drshadow/springboot/ShadowTrafficAdapterTest.java
@@ -92,21 +92,9 @@ public class ShadowTrafficAdapterTest {
     }
 
     @Test
-    public void testInvokeShadowTrafficWithConfigAsFalse_expectNoShadowTrafficPerformed() {
-
-        when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(false);
-
-        shadowTrafficAdapter.invokeShadowTraffic(shadowServletRequest, originalServletRequest);
-
-        verify(restTemplate, times(0)).exchange(any(), any(), any(), eq(String.class));
-    }
-
-    @Test
     public void testInvokeShadowTrafficWithRandomValueGreaterThanPercentageConfigured_expectNoShadowTrafficPerformed() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(51);
 
@@ -119,7 +107,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTrafficWithNullDrShadowServletRequest_expectNoShadowTrafficPerformed() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
 
@@ -132,7 +119,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTrafficWithNullOriginalRequest_expectNoShadowTrafficPerformed() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
 
@@ -145,7 +131,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTrafficWithNullMethod_expectNoShadowTrafficPerformed() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn(null);
@@ -160,7 +145,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_withHttpsHost() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");
@@ -190,7 +174,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_withHttpHost() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");
@@ -220,7 +203,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_verifyOriginalUrlEncodedParamsDoesNotDoubleEncode() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");
@@ -251,7 +233,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_verifyWithPostBody() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");
@@ -283,7 +264,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_verifyWithCustomHeaders() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");
@@ -319,7 +299,6 @@ public class ShadowTrafficAdapterTest {
     public void testInvokeShadowTraffic_verifyApplicationJsonUTF8Set() {
 
         when(shadowTrafficConfigHelper.getConfig()).thenReturn(shadowTrafficConfig);
-        when(shadowTrafficConfig.isEnabled()).thenReturn(true);
         when(shadowTrafficConfig.getPercentage()).thenReturn(50);
         when(random.nextInt(eq(100))).thenReturn(30);
         when(shadowServletRequest.getMethod()).thenReturn("GET");


### PR DESCRIPTION
# dr-shadow PR

The `ShadowTrafficAdapter`'s invocation of shadow traffic checks if shadow traffic config is enabled. This check is redundant as it is already being taken care at shouldNotFilter() method in the `ShadowTrafficFilter`. This PR gets rid of that check.

## Added
None

## Changed
None

## Deleted
Removed `shadowTrafficConfig.isEnabled()` check inside `invokeShadowTraffic()` method


# PR Checklist Forms

_(to be filled out by PR submitter)_
- [x] This template filled (above this section)
- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
- [ ] Milestone selected
- [x] All files reviewed before sending to reviewers
- [ ] Any annotations for reviewers have been added
      (with preference of annotating directly in code comments)
- [x] PR builds successfully
- [ ] Tested with the provided sample test app